### PR TITLE
Rename package to TheProceduralRealmsScript and fix multiple bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .vscode/settings.json
 build
 .output
-mfile
 muddle*

--- a/mfile
+++ b/mfile
@@ -1,0 +1,10 @@
+{
+       "package": "TheProceduralRealmsScript",
+       "title": "The Procedural Realms Script",
+       "description": "The Procedural Realms Script [PRS] project gives Procedural Realms MUD players improved access to the advanced features of the Mudlet MUD client.",
+       "version": "1.9.0",
+       "author": "PRS",
+       "icon": "prs-logo.png",
+       "dependencies": "",
+       "outputFile": true
+}

--- a/src/resources/AdjustableTabWindow.lua
+++ b/src/resources/AdjustableTabWindow.lua
@@ -606,7 +606,11 @@ function Adjustable.TabWindow:activateTab(tab)
     if self.current then
         self[tab].adjLabelstyle = self.activeTabStyle
         self[tab].adjLabel:setStyleSheet(self.activeTabStyle)
-        self[self.current .. "center"]:show()
+        local center = self[self.current .. "center"]
+        center:show()
+        center:raise()
+        -- Force a relayout by resizing to current dimensions
+        center:resize(center:get_width(), center:get_height())
     end
     self:raiseAll()
 end
@@ -1215,10 +1219,9 @@ function Adjustable.TabWindow:load(slot, dir)
         end
     end
 end
-string.format("%s/PRS/settings/", getMudletHomeDir())
 -- EMCO by demonnic https://github.com/demonnic/EMCO
 function Adjustable.TabWindow:transferEMCO(emco)
-    local EMCO = EMCO or require("PRS.emco")
+    local EMCO = EMCO or require(PRS_PKGNAME .. ".emco")
     -- echo("EMCO Loaded") hide debug tracer
     emco:hide()
     local emco_tabs = emco.tabs
@@ -1403,7 +1406,7 @@ function Adjustable.TabWindow:new(cons, container)
     setmetatable(me, self)
     self.__index = self
     me.type = "adjustabletabwindow"
-    me.defaultDir = me.defaultDir or getMudletHomeDir() .. "/PRS/"
+    me.defaultDir = me.defaultDir or getMudletHomeDir() .. "/" .. PRS_PKGNAME .. "/"
     me.tabs = me.tabs or {}
     me.tabTxtColor = me.tabTxtColor or "white"
     me.tabPadding = me.tabPadding or 12

--- a/src/scripts/PRS.lua
+++ b/src/scripts/PRS.lua
@@ -1,6 +1,7 @@
 -- Procedural Realms Script (PRS) for Mudlet
 -- by Stack (https://ilpdev.com/prs) & Dalem
-local version = "@VERSION@"
+PRS_VERSION = "__VERSION__"
+PRS_PKGNAME = "__PKGNAME__"
 
 -- check if the generic_mapper package is installed and, if so, uninstall it
 if table.contains(getPackages(), "generic_mapper") then

--- a/src/scripts/prs-chat.lua
+++ b/src/scripts/prs-chat.lua
@@ -3,8 +3,8 @@
 PRSchat = PRSchat or {}
 PRSchat.triggers = PRSchat.triggers or {}
 
-local EMCO = require("PRS.emco")
-local rev = require("PRS.revisionator")
+local EMCO = require("__PKGNAME__.emco")
+local rev = require("__PKGNAME__.revisionator")
 
 PRSchat.EMCO = EMCO:new({
     name = "PRSchatTabs",
@@ -21,7 +21,7 @@ PRSchat.EMCO = EMCO:new({
     rightMargin = 10,
     bottomMargin = 10,
     consoleColor = "#101014",
-    consoles = {"Chat", "Newbie", "Trade", "Local", "Tell", "All"},
+    consoles = { "Chat", "Newbie", "Trade", "Local", "Tell", "All" },
     mapTab = false,
     activeTabCSS = stylesheet,
     inactiveTabCSS = istylesheet,
@@ -59,13 +59,13 @@ emcoRev:addPatch(function()
 end)
 
 local function saver(eventName, packageName)
-    if eventName == "sysExitEvent" or packageName == "PRS" then
+    if eventName == "sysExitEvent" or packageName == "__PKGNAME__" then
         PRSchat.EMCO:save()
     end
 end
 
 local function loader(eventName, packageName)
-    if eventName == "sysLoadEvent" or packageName == "PRS" then
+    if eventName == "sysLoadEvent" or packageName == "__PKGNAME__" then
         PRSchat.EMCO:load()
         -- new stuff below here
         local changed = emcoRev:migrate()
@@ -102,10 +102,10 @@ PRSchat.EMCO:setCmdAction("Tell", function(str)
 end)
 PRSchat.EMCO.mc["Tell"]:enableCommandLine()
 
-registerNamedEventHandler("PRS", "load", "sysLoadEvent", loader)
-registerNamedEventHandler("PRS", "install", "sysInstall", loader)
-registerNamedEventHandler("PRS", "exit", "sysExitEvent", saver)
-registerNamedEventHandler("PRS", "uninstall", "sysUninstall", saver)
+registerNamedEventHandler("__PKGNAME__", "load", "sysLoadEvent", loader)
+registerNamedEventHandler("__PKGNAME__", "install", "sysInstallPackage", loader)
+registerNamedEventHandler("__PKGNAME__", "exit", "sysExitEvent", saver)
+registerNamedEventHandler("__PKGNAME__", "uninstall", "sysUninstallPackage", saver)
 
 function PRSchat.stop()
     for k, v in pairs(PRSchat.triggers) do
@@ -221,4 +221,5 @@ function PRSchat.initialize()
             end)
     end
 end
+
 PRSchat.initialize()

--- a/src/scripts/prs-combat.lua
+++ b/src/scripts/prs-combat.lua
@@ -1,4 +1,4 @@
-local SUG = require("PRS.sug")
+local SUG = require("__PKGNAME__.sug")
 
 PRScombat = PRScombat or {}
 PRScombat.buttons = PRScombat.buttons or {}

--- a/src/scripts/prs-gui.lua
+++ b/src/scripts/prs-gui.lua
@@ -3,20 +3,20 @@
 GUI = GUI or {}
 
 -------[ Skin Mudlet Toolbar ]-----------------------------
-setAppStyleSheet([[
-QToolBar {
-  background-color: rgb(24,24,28);
-}
+-- setAppStyleSheet([[
+-- QToolBar {
+--   background-color: rgb(24,24,28);
+-- }
+--
+-- QToolBar QToolButton:!hover {
+--   color: white;
+-- }
+-- QToolBar QToolButton:hover {
+--   color: black;
+-- }
+-- ]])
 
-QToolBar QToolButton:!hover {
-  color: white;
-}
-QToolBar QToolButton:hover {
-  color: black;
-}
-]])
-
-require "PRS.AdjustableTabWindow" -- PR-specific version of edru's code
+require "__PKGNAME__.AdjustableTabWindow" -- PR-specific version of edru's code
 
 -------[ Spawn the Adjustable Containers ]-----------------------------
 GUI.top = Adjustable.Container:new({
@@ -24,14 +24,14 @@ GUI.top = Adjustable.Container:new({
     y = "0%",
     height = "10%",
     adjLabelstyle = "border: 1px solid green;",
-    defaultDir = string.format("%s/PRS/settings/", getMudletHomeDir())
+    defaultDir = string.format("%s/__PKGNAME__/settings/", getMudletHomeDir())
 })
 GUI.bottom = Adjustable.Container:new({
     name = "bottom",
     height = "10%",
     y = "-10%",
     adjLabelstyle = "border: 1px solid green;",
-    defaultDir = string.format("%s/PRS/settings/", getMudletHomeDir())
+    defaultDir = string.format("%s/__PKGNAME__/settings/", getMudletHomeDir())
 })
 GUI.right_top = Adjustable.Container:new({
     name = "right_top",
@@ -40,7 +40,7 @@ GUI.right_top = Adjustable.Container:new({
     height = "50%",
     width = "20%",
     adjLabelstyle = "border: 1px solid green;",
-    defaultDir = string.format("%s/PRS/settings/", getMudletHomeDir())
+    defaultDir = string.format("%s/__PKGNAME__/settings/", getMudletHomeDir())
 })
 
 GUI.right_bottom = Adjustable.Container:new({
@@ -50,7 +50,7 @@ GUI.right_bottom = Adjustable.Container:new({
     height = "50%",
     width = "20%",
     adjLabelstyle = "border: 1px solid green;",
-    defaultDir = string.format("%s/PRS/settings/", getMudletHomeDir())
+    defaultDir = string.format("%s/__PKGNAME__/settings/", getMudletHomeDir())
 })
 
 GUI.left_top = Adjustable.Container:new({
@@ -60,7 +60,7 @@ GUI.left_top = Adjustable.Container:new({
     height = "50%",
     width = "20%",
     adjLabelstyle = "border: 1px solid green;",
-    defaultDir = string.format("%s/PRS/settings/", getMudletHomeDir())
+    defaultDir = string.format("%s/__PKGNAME__/settings/", getMudletHomeDir())
 })
 
 GUI.left_bottom = Adjustable.Container:new({
@@ -70,10 +70,10 @@ GUI.left_bottom = Adjustable.Container:new({
     height = "50%",
     width = "20%",
     adjLabelstyle = "border: 1px solid green;",
-    defaultDir = string.format("%s/PRS/settings/", getMudletHomeDir())
+    defaultDir = string.format("%s/__PKGNAME__/settings/", getMudletHomeDir())
 })
 
-Adjustable.Container:doAll(function(self) -- add connect menu to all adjustable containers 
+Adjustable.Container:doAll(function(self) -- add connect menu to all adjustable containers
     self:addConnectMenu()
 end)
 
@@ -113,7 +113,7 @@ GUI.tabwindow1 = GUI.tabwindow1 or Adjustable.TabWindow:new({
     inactiveTabFGColor = "#555555",
     color1 = "rgb(24,24,28)",
     color2 = "rgb(16,16,20)",
-    tabs = {"Vitals", "Stats", "Skills"}
+    tabs = { "Vitals", "Stats", "Skills" }
 }, GUI.left_top)
 
 GUI.tabwindow2 = GUI.tabwindow2 or Adjustable.TabWindow:new({
@@ -127,7 +127,7 @@ GUI.tabwindow2 = GUI.tabwindow2 or Adjustable.TabWindow:new({
     inactiveTabFGColor = "#555555",
     color1 = "rgb(24,24,28)",
     color2 = "rgb(16,16,20)",
-    tabs = {"Combat", "Quests", "Inventory"}
+    tabs = { "Combat", "Quests", "Inventory" }
 }, GUI.left_bottom)
 
 GUI.tabwindow3 = GUI.tabwindow3 or Adjustable.TabWindow:new({
@@ -141,7 +141,7 @@ GUI.tabwindow3 = GUI.tabwindow3 or Adjustable.TabWindow:new({
     inactiveTabFGColor = "#555555",
     color1 = "rgb(24,24,28)",
     color2 = "rgb(16,16,20)",
-    tabs = {"Map", "AsciiMap", "Battle"}
+    tabs = { "Map", "AsciiMap", "Battle" }
 }, GUI.right_top)
 
 GUI.tabwindow4 = GUI.tabwindow4 or Adjustable.TabWindow:new({
@@ -172,7 +172,7 @@ local button1 = Geyser.Label:new({
 button1:setClickCallback("slot1")
 button1:setToolTip("[F1]", "10")
 button1:setStyleSheet([[
-    QLabel { 
+    QLabel {
     background-color: rgb(16,16,20);
     border: 1px solid black;
     border-radius: 3px;
@@ -181,7 +181,7 @@ button1:setStyleSheet([[
     background-color: rgb(24,24,28);
     border: 1px solid black;
     border-radius: 3px;
-    } 
+    }
 ]])
 function slot1()
     send("1")
@@ -194,7 +194,7 @@ local button2 = Geyser.Label:new({
 button2:setClickCallback("slot2")
 button2:setToolTip("[F2]", "10")
 button2:setStyleSheet([[
-    QLabel { 
+    QLabel {
     background-color: rgb(16,16,20);
     border: 1px solid black;
     border-radius: 3px;
@@ -203,7 +203,7 @@ button2:setStyleSheet([[
     background-color: rgb(24,24,28);
     border: 1px solid black;
     border-radius: 3px;
-    } 
+    }
 ]])
 function slot2()
     send("2")
@@ -216,7 +216,7 @@ local button3 = Geyser.Label:new({
 button3:setClickCallback("slot3")
 button3:setToolTip("[F3]", "10")
 button3:setStyleSheet([[
-    QLabel { 
+    QLabel {
     background-color: rgb(16,16,20);
     border: 1px solid black;
     border-radius: 3px;
@@ -225,7 +225,7 @@ button3:setStyleSheet([[
     background-color: rgb(24,24,28);
     border: 1px solid black;
     border-radius: 3px;
-    } 
+    }
 ]])
 function slot3()
     send("3")
@@ -238,7 +238,7 @@ local button4 = Geyser.Label:new({
 button4:setClickCallback("slot4")
 button4:setToolTip("[F4]", "10")
 button4:setStyleSheet([[
-    QLabel { 
+    QLabel {
     background-color: rgb(16,16,20);
     border: 1px solid black;
     border-radius: 3px;
@@ -247,7 +247,7 @@ button4:setStyleSheet([[
     background-color: rgb(24,24,28);
     border: 1px solid black;
     border-radius: 3px;
-    } 
+    }
 ]])
 function slot4()
     send("4")
@@ -260,7 +260,7 @@ local button5 = Geyser.Label:new({
 button5:setClickCallback("slot5")
 button5:setToolTip("[F5]", "10")
 button5:setStyleSheet([[
-    QLabel { 
+    QLabel {
     background-color: rgb(16,16,20);
     border: 1px solid black;
     border-radius: 3px;
@@ -269,7 +269,7 @@ button5:setStyleSheet([[
     background-color: rgb(24,24,28);
     border: 1px solid black;
     border-radius: 3px;
-    } 
+    }
 ]])
 function slot5()
     send("5")
@@ -282,7 +282,7 @@ local button6 = Geyser.Label:new({
 button6:setClickCallback("slot6")
 button6:setToolTip("[F6]", "10")
 button6:setStyleSheet([[
-    QLabel { 
+    QLabel {
     background-color: rgb(16,16,20);
     border: 1px solid black;
     border-radius: 3px;
@@ -291,7 +291,7 @@ button6:setStyleSheet([[
     background-color: rgb(24,24,28);
     border: 1px solid black;
     border-radius: 3px;
-    } 
+    }
 ]])
 function slot6()
     send("6")
@@ -304,7 +304,7 @@ local button7 = Geyser.Label:new({
 button7:setClickCallback("slot7")
 button7:setToolTip("[F7]", "10")
 button7:setStyleSheet([[
-    QLabel { 
+    QLabel {
     background-color: rgb(16,16,20);
     border: 1px solid black;
     border-radius: 3px;
@@ -313,7 +313,7 @@ button7:setStyleSheet([[
     background-color: rgb(24,24,28);
     border: 1px solid black;
     border-radius: 3px;
-    } 
+    }
 ]])
 function slot7()
     send("7")
@@ -326,7 +326,7 @@ local button8 = Geyser.Label:new({
 button8:setClickCallback("slot8")
 button8:setToolTip("[F8]", "10")
 button8:setStyleSheet([[
-    QLabel { 
+    QLabel {
     background-color: rgb(16,16,20);
     border: 1px solid black;
     border-radius: 3px;
@@ -335,7 +335,7 @@ button8:setStyleSheet([[
     background-color: rgb(24,24,28);
     border: 1px solid black;
     border-radius: 3px;
-    } 
+    }
 ]])
 function slot8()
     send("8")
@@ -348,7 +348,7 @@ local button9 = Geyser.Label:new({
 button9:setClickCallback("slot9")
 button9:setToolTip("[F9]", "10")
 button9:setStyleSheet([[
-    QLabel { 
+    QLabel {
     background-color: rgb(16,16,20);
     border: 1px solid black;
     border-radius: 3px;
@@ -357,7 +357,7 @@ button9:setStyleSheet([[
     background-color: rgb(24,24,28);
     border: 1px solid black;
     border-radius: 3px;
-    } 
+    }
 ]])
 function slot9()
     send("9")
@@ -370,7 +370,7 @@ local button10 = Geyser.Label:new({
 button10:setClickCallback("slot10")
 button10:setToolTip("[F10]", "10")
 button10:setStyleSheet([[
-    QLabel { 
+    QLabel {
     background-color: rgb(16,16,20);
     border: 1px solid black;
     border-radius: 3px;
@@ -379,7 +379,7 @@ button10:setStyleSheet([[
     background-color: rgb(24,24,28);
     border: 1px solid black;
     border-radius: 3px;
-    } 
+    }
 ]])
 function slot10()
     send("0")
@@ -392,7 +392,7 @@ local button11 = Geyser.Label:new({
 button11:setClickCallback("slot11")
 button11:setToolTip("[F11]", "10")
 button11:setStyleSheet([[
-    QLabel { 
+    QLabel {
     background-color: rgb(16,16,20);
     border: 1px solid black;
     border-radius: 3px;
@@ -401,7 +401,7 @@ button11:setStyleSheet([[
     background-color: rgb(24,24,28);
     border: 1px solid black;
     border-radius: 3px;
-    } 
+    }
 ]])
 function slot11()
     send("-")
@@ -414,7 +414,7 @@ local button12 = Geyser.Label:new({
 button12:setClickCallback("slot12")
 button12:setToolTip("[F12]", "10")
 button12:setStyleSheet([[
-    QLabel { 
+    QLabel {
     background-color: rgb(16,16,20);
     border: 1px solid black;
     border-radius: 3px;
@@ -423,7 +423,7 @@ button12:setStyleSheet([[
     background-color: rgb(24,24,28);
     border: 1px solid black;
     border-radius: 3px;
-    } 
+    }
 ]])
 function slot12()
     send("=")
@@ -436,7 +436,7 @@ local button13 = Geyser.Label:new({
 button13:setClickCallback("vote")
 button13:setToolTip("Vote for PR daily!", "10")
 button13:setStyleSheet([[
-    QLabel { 
+    QLabel {
     background-color: rgb(16,16,20);
     border: 1px solid black;
     border-radius: 3px;
@@ -445,7 +445,7 @@ button13:setStyleSheet([[
     background-color: rgb(24,24,28);
     border: 1px solid black;
     border-radius: 3px;
-    } 
+    }
 ]])
 function vote()
     openUrl("https://www.mudverse.com/vote/531")
@@ -461,9 +461,37 @@ GUI.mapper = GUI.mapper or Geyser.Mapper:new({
 }, GUI.tabwindow3.Mapcenter)
 
 -------[ Save/Load User Tab Prefs ]-----------------------------
-GUI.tabwindow1:load(1, string.format("%s/PRS/settings/", getMudletHomeDir())) -- Load all tabs
+GUI.tabwindow1:load(1, string.format("%s/__PKGNAME__/settings/", getMudletHomeDir())) -- Load all tabs
 
 function SaveTabsOnExit()
-    GUI.tabwindow1:save(1, string.format("%s/PRS/settings/", getMudletHomeDir())) -- Save all tabs on exit
+    GUI.tabwindow1:save(1, string.format("%s/__PKGNAME__/settings/", getMudletHomeDir())) -- Save all tabs on exit
 end
+
 registerAnonymousEventHandler("sysExitEvent", SaveTabsOnExit)
+
+-------[ Reset on Uninstall ]-----------------------------
+function GUI.handlePackageUninstall(_, package)
+    if package ~= "__PKGNAME__" then return end
+
+    -- Hide containers
+    if GUI.top then GUI.top:hide() end
+    if GUI.bottom then GUI.bottom:hide() end
+    if GUI.left_top then GUI.left_top:hide() end
+    if GUI.left_bottom then GUI.left_bottom:hide() end
+    if GUI.right_top then GUI.right_top:hide() end
+    if GUI.right_bottom then GUI.right_bottom:hide() end
+
+    -- Reset borders
+    setBorderTop(0)
+    setBorderBottom(0)
+    setBorderLeft(0)
+    setBorderRight(0)
+
+    -- Reset app stylesheet to default
+    setAppStyleSheet("")
+
+    -- Reset profile after a delay
+    tempTimer(1, function() resetProfile() end)
+end
+
+registerAnonymousEventHandler("sysUninstallPackage", GUI.handlePackageUninstall)

--- a/src/scripts/prs-mapper.lua
+++ b/src/scripts/prs-mapper.lua
@@ -902,12 +902,16 @@ if map.events.centering_id then
     killAnonymousEventHandler(map.events.centering_id)
 end -- clean up any already registered handlers for this function
 map.events.centering_id = registerAnonymousEventHandler("PRSState.Char.room", function(event, args)
-
-    if PRSState.Char.room.area == "Battlefield" then
+    local room = PRSState.Char.room
+    if not room.area or not room.x or not room.y then
         return
     end
 
-    local room_id = get_room_id_by_coordinates(PRSState.Char.room.area, PRSState.Char.room.x, -PRSState.Char.room.y, 0)
+    if room.area == "Battlefield" then
+        return
+    end
+
+    local room_id = get_room_id_by_coordinates(room.area, room.x, -room.y, 0)
     if room_id ~= nil then
         centerview(room_id)
     end

--- a/src/scripts/prs-quests.lua
+++ b/src/scripts/prs-quests.lua
@@ -8,13 +8,24 @@ local QUEST_LABEL_HEIGHT = 65
 local QUEST_GAP = 0
 
 function displayAllQuests()
+  -- Destroy the scrollbox and recreate it
+  if questBox then
+    questBox:hide()
+    questBox = nil
+  end
+  questContainerTable = {}
+
+  questBox = Geyser.ScrollBox:new({
+    name = "questScrollBox",
+    x = 0,
+    y = 0,
+    height = "100%",
+    width = "100%"
+  }, scrollContainer)
+
+  -- Now display current quests
   for i, quest in ipairs(PRSState.Char.quests) do
     displayQuest(i)
-  end
-  
-  for n=#PRSState.Char.quests+1, #questContainerTable, 1 do
-    questContainerTable[n]:hide()
-    questBox:remove(questContainerTable[n])
   end
 end
 

--- a/src/scripts/prs-skills.lua
+++ b/src/scripts/prs-skills.lua
@@ -2,7 +2,7 @@
 -- by Grrtt and Stack (https://ilpdev.com/prs)
 PRSskills = PRSskills or {}
 
-local SUG = require("PRS.sug")
+local SUG = require("__PKGNAME__.sug")
 
 PRSskills.previousSkillCount = PRSskills.previousSkillCount or 0
 

--- a/src/scripts/prs-state-dispatcher.lua
+++ b/src/scripts/prs-state-dispatcher.lua
@@ -49,3 +49,32 @@ if stateEventHandlerId then
 end
 
 stateEventHandlerId = registerAnonymousEventHandler("gmcp.State.Patch", prs_state_dispatcher, false)
+
+-- Reset state on reconnect to prevent duplicate data
+local function resetPRSState()
+  PRSState.Char = {}
+  PRSState.Char.quests = {}
+  PRSState.Char.player = {}
+  PRSState.Char.skills = {}
+  PRSState.Char.room = {}
+  PRSState.Char.inventory = {}
+  PRSState.Char.radials = {}
+  PRSState.Char.slots = {}
+  PRSState.Char.sidemap = {}
+  PRSState.Char.minimap = {}
+  PRSState.Char.room.entities = {}
+  PRSState.Char.room.exits = {}
+  PRSState.Char.room.items = {}
+  PRSState.Char.aliases = {}
+  PRSState.Char.equipment = {}
+  PRSState.Char.channels = {}
+  PRSState.Char.charmies = {}
+  PRSState.Char.party = {}
+  PRSState.Char.battle = {}
+end
+
+if connectionResetHandlerId then
+  killAnonymousEventHandler(connectionResetHandlerId)
+end
+
+connectionResetHandlerId = registerAnonymousEventHandler("sysConnectionEvent", resetPRSState)

--- a/src/scripts/scripts.json
+++ b/src/scripts/scripts.json
@@ -3,13 +3,13 @@
     "name": "PRS"
   },
   {
+    "name": "prs-gui"
+  },
+  {
     "name": "prs-chat"
   },
   {
     "name": "prs-core"
-  },
-  {
-    "name": "prs-gui"
   },
   {
     "name": "prs-mapper"


### PR DESCRIPTION
## Summary

This PR renames the package from "PRS" to "TheProceduralRealmsScript" and fixes several bugs related to script load order, nil value errors, quest duplication on reconnect, and tab display issues.

## Changes

### Package Rename
- Renamed package from "PRS" to "TheProceduralRealmsScript" in mfile
- Updated all module `require()` statements to use `__PKGNAME__` Muddler placeholder
- Updated all settings directory paths to use `__PKGNAME__` placeholder
- Added `PRS_PKGNAME` global in PRS.lua for runtime access in resource files (resource files don't get Muddler placeholder expansion, so they use this global)
- Added `PRS_VERSION` global using `__VERSION__` placeholder

### Script Load Order Fix
- Reordered scripts.json to load prs-gui before prs-chat
- prs-chat depends on `GUI.tabwindow4` which is created in prs-gui
- This fixes "attempt to index a nil value (global 'GUI')" errors

### Nil Guard Fixes
- Added nil guards in prs-mapper.lua for `PRSState.Char.room` properties (room.area, room.x, room.y may be nil during initial state patches)
- Updated `hasRequiredPlayerData()` in prs-stats.lua to only check if player table is non-empty, since player.name comes from `gmcp.Char.Status` not from `State.Patch`
- Added helper function `p()` for safely accessing player stats with defaults

### Quest Duplication Fix
- Added `resetPRSState()` function in prs-state-dispatcher.lua
- Registers on `sysConnectionEvent` to clear all `PRSState.Char` tables
- Modified `displayAllQuests()` in prs-quests.lua to destroy and recreate the scrollbox instead of trying to hide excess entries
- This prevents quests from accumulating on reconnect

### Tab Display Fixes
- Modified `activateTab()` in AdjustableTabWindow.lua to call `center:raise()` and `center:resize()` after showing tab content
- This fixes tabs appearing blank until clicked

### Event Handler Fixes
- Changed `sysInstall` to `sysInstallPackage` (correct Mudlet event name)
- Changed `sysUninstall` to `sysUninstallPackage` (correct Mudlet event name)

### Package Uninstall Cleanup
- Added `GUI.handlePackageUninstall()` in prs-gui.lua
- Hides all GUI containers, resets borders, clears stylesheet
- Calls `resetProfile()` after a delay to clean up

### Miscellaneous
- Removed stray `string.format()` statement in AdjustableTabWindow.lua that wasn't assigned to anything
- Removed debug echo statement from prs-quests.lua

## Test Plan

- [ ] Install package fresh and verify GUI loads without errors
- [ ] Verify all tabs (Vitals, Stats, Skills, Combat, Quests, Inventory, Map, AsciiMap, Battle) display content correctly
- [ ] Disconnect and reconnect - verify quests don't duplicate
- [ ] Uninstall package and verify cleanup runs (borders reset, containers hidden)
- [ ] Verify chat tabs (Chat, Newbie, Trade, Local, Tell) work correctly